### PR TITLE
fixed: Telegram connection failed #99

### DIFF
--- a/app/src/main/java/com/android/xrayfa/parser/AbstractConfigParser.kt
+++ b/app/src/main/java/com/android/xrayfa/parser/AbstractConfigParser.kt
@@ -114,6 +114,16 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject> {
                     RuleObject(
                         type = "field",
                         outboundTag = "proxy",
+                        domain = listOf("geosite:telegram"),
+                    ),
+                    RuleObject(
+                        type = "field",
+                        outboundTag = "proxy",
+                        ip = listOf("geoip:telegram")
+                    ),
+                    RuleObject(
+                        type = "field",
+                        outboundTag = "proxy",
                         domain = listOf("geosite:geolocation-!cn")
                     ),
                     RuleObject(


### PR DESCRIPTION
fix(parser) 

[Why]
Telegram connection failed

[What]
- add route for telegram

[Test]
- open telegram connect to server

Fixes: #99 
