### PR TITLE
redesign NodeCard with cleaner Material 3 styling

### DIFF
--- a/app/src/main/java/com/android/xrayfa/ui/component/ConfigScreen.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/ConfigScreen.kt
@@ -423,9 +423,11 @@ fun ConfigScreen(
 
                             if(node != nodes.last()) {
                                 HorizontalDivider(
-                                    modifier = Modifier.fillMaxSize()
-                                        .padding(horizontal = 48.dp),
-                                    thickness = 1.dp
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(start = 86.dp, end = 16.dp),
+                                    thickness = 0.6.dp,
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                                 )
                             }
                         }
@@ -584,9 +586,11 @@ fun ConfigScreen(
                         )
                         if (node != queryNodes.last()) {
                             HorizontalDivider(
-                                modifier = Modifier.fillMaxSize()
-                                    .padding(horizontal = 48.dp),
-                                thickness = 1.dp
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(start = 86.dp, end = 16.dp),
+                                thickness = 0.6.dp,
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                             )
                         }
                     }

--- a/app/src/main/java/com/android/xrayfa/ui/component/NodeCard.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/NodeCard.kt
@@ -2,7 +2,6 @@ package com.android.xrayfa.ui.component
 
 import android.annotation.SuppressLint
 import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -10,25 +9,26 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Dns
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -38,29 +38,24 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.xrayfa.R
 import com.android.xrayfa.dto.Node
 import com.android.xrayfa.model.protocol.protocolPrefixMap
-import com.android.xrayfa.utils.ColorMap
-
-import androidx.compose.material.icons.outlined.Speed
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.res.stringResource
-import com.android.xrayfa.R
 
 @SuppressLint("ConfigurationScreenWidthHeight")
 @Composable
 fun NodeCard(
-    backgroundColor: Color = MaterialTheme.colorScheme.surface,
+    backgroundColor: Color = Color.Unspecified,
     node: Node,
     modifier: Modifier = Modifier,
     delete: (() -> Unit)? = null,
@@ -77,172 +72,274 @@ fun NodeCard(
     roundCorner: Boolean = false,
     countryEmoji: String = ""
 ) {
-    val context = LocalContext.current
-    val interactionSource = remember { MutableInteractionSource() }
-    val delayColor = when {
-        delayMs == -2L -> MaterialTheme.colorScheme.error
-        delayMs < 0 -> Color.Transparent
-        delayMs < 300 -> Color(0xFF4CAF50)
-        delayMs < 900 -> Color(0xFFFFA000)
-        else -> Color(0xFFF44336)
-    }
-    
-    val elevation by animateDpAsState(
-        targetValue = if (selected) 8.dp else 2.dp,
-        label = "elevation"
-    )
-
-    ElevatedCard(
-        onClick = onChoose,
-        modifier = modifier.fillMaxWidth(),
-        shape = if (roundCorner) RoundedCornerShape(24.dp) else RoundedCornerShape(12.dp),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else backgroundColor
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = elevation)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
+    if (roundCorner) {
+        // Standalone card mode (e.g. HomeScreen): ElevatedCard with rounded corners and subtle shadow
+        ElevatedCard(
+            onClick = onChoose,
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = if (backgroundColor != Color.Unspecified) backgroundColor
+                else MaterialTheme.colorScheme.surfaceContainerLow
+            ),
+            elevation = CardDefaults.elevatedCardElevation(
+                defaultElevation = 1.dp,
+                pressedElevation = 2.dp
+            )
         ) {
-            // Node Icon / Emoji
+            NodeCardContent(
+                node = node,
+                delete = delete,
+                onShare = onShare,
+                onEdit = onEdit,
+                onTest = onTest,
+                delayMs = delayMs,
+                testing = testing,
+                selected = selected,
+                favorite = favorite,
+                onFavorite = onFavorite,
+                enableTest = enableTest,
+                countryEmoji = countryEmoji,
+                showSelectionIndicator = false,
+                contentPadding = 16.dp
+            )
+        }
+    } else {
+        // List mode (ConfigScreen): flat Row, selection indicated only by the leading bar
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .clickable(onClick = onChoose)
+        ) {
+            NodeCardContent(
+                node = node,
+                delete = delete,
+                onShare = onShare,
+                onEdit = onEdit,
+                onTest = onTest,
+                delayMs = delayMs,
+                testing = testing,
+                selected = selected,
+                favorite = favorite,
+                onFavorite = onFavorite,
+                enableTest = enableTest,
+                countryEmoji = countryEmoji,
+                showSelectionIndicator = true,
+                contentPadding = 12.dp
+            )
+        }
+    }
+}
+
+@Composable
+private fun NodeCardContent(
+    node: Node,
+    delete: (() -> Unit)?,
+    onShare: (() -> Unit)?,
+    onEdit: (() -> Unit)?,
+    onTest: (() -> Unit)?,
+    delayMs: Long,
+    testing: Boolean,
+    selected: Boolean,
+    favorite: Boolean,
+    onFavorite: (() -> Unit)?,
+    enableTest: Boolean,
+    countryEmoji: String,
+    showSelectionIndicator: Boolean,
+    contentPadding: androidx.compose.ui.unit.Dp
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = contentPadding),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Selection indicator bar (list mode only)
+        if (showSelectionIndicator) {
             Box(
                 modifier = Modifier
-                    .size(48.dp)
-                    .clip(CircleShape)
-                    .background(ColorMap.getValue(node.subscriptionId).copy(alpha = 0.8f)),
-                contentAlignment = Alignment.Center
-            ) {
-                if (countryEmoji.isNotEmpty()) {
-                    Text(text = countryEmoji, style = MaterialTheme.typography.titleLarge)
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Star,
-                        contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(24.dp)
+                    .width(3.dp)
+                    .height(36.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(
+                        if (selected) MaterialTheme.colorScheme.primary
+                        else Color.Transparent
                     )
-                }
-            }
+            )
+            Spacer(Modifier.width(12.dp))
+        }
 
-            Spacer(Modifier.width(16.dp))
-
-            // Node Info
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = node.remark ?: node.address,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    modifier = Modifier.basicMarquee()
+        // Avatar / Emoji
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            if (countryEmoji.isNotEmpty()) {
+                Text(text = countryEmoji, fontSize = 22.sp)
+            } else {
+                Icon(
+                    imageVector = Icons.Outlined.Dns,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(20.dp)
                 )
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = protocolPrefixMap[node.protocolPrefix]?.protocolType ?: stringResource(
-                            R.string.unknown),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    
-                    if (onFavorite != null) {
-                        Box(
-                            modifier = Modifier
-                                .padding(start = 4.dp)
-                                .size(40.dp)
-                                .clickable(
-                                    interactionSource = interactionSource,
-                                    indication = null
-                                ) {
-                                    onFavorite.invoke()
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = if (favorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-                                contentDescription = if (favorite) stringResource(R.string.remove_from_favorites) else stringResource(R.string.add_to_favorites),
-                                tint = if (favorite) Color.Red else Color.Gray,
-                                modifier = Modifier.size(20.dp)
-                            )
-                        }
-                    }
-
-                    if (delayMs > 0 || delayMs == -2L) {
-                        val displayText = if (delayMs == -2L) stringResource(R.string.timeout) else "${delayMs}ms"
-                        Spacer(Modifier.width(8.dp))
-                        Box(
-                            modifier = Modifier
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(delayColor.copy(alpha = 0.1f))
-                                .padding(horizontal = 4.dp, vertical = 2.dp)
-                        ) {
-                            Text(
-                                text = displayText,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = delayColor,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
-                }
             }
+        }
 
-            // Actions
-            Row {
-                if (onTest != null) {
-                    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
-                    
-                    // Pulsing scale animation
-                    val scale by infiniteTransition.animateFloat(
-                        initialValue = 1f,
-                        targetValue = if (testing) 1.2f else 1f,
-                        animationSpec = infiniteRepeatable(
-                            animation = tween(800, easing = LinearEasing),
-                            repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
-                        ),
-                        label = "scale"
-                    )
-                    
-                    // Subtle alpha blinking
-                    val alpha by infiniteTransition.animateFloat(
-                        initialValue = 1f,
-                        targetValue = if (testing) 0.4f else 1f,
-                        animationSpec = infiniteRepeatable(
-                            animation = tween(800, easing = LinearEasing),
-                            repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
-                        ),
-                        label = "alpha"
-                    )
+        Spacer(Modifier.width(14.dp))
 
-                    IconButton(onClick = onTest, enabled = enableTest) {
-                        Icon(
-                            imageVector = Icons.Outlined.Speed,
-                            contentDescription = stringResource(R.string.test_url),
-                            modifier = Modifier.scale(scale),
-                            tint = if (enableTest) {
-                                MaterialTheme.colorScheme.primary.copy(alpha = alpha)
-                            } else Color.Gray
-                        )
-                    }
-                }
-                if (onShare != null) {
-                    IconButton(onClick = onShare) {
-                        Icon(Icons.Default.Share, contentDescription = stringResource(R.string.clipboard_export))
-                    }
-                }
-                if (onEdit != null) {
-                    IconButton(onClick = onEdit) {
-                        Icon(Icons.Filled.Edit, contentDescription = stringResource(R.string.edit))
-                    }
-                }
-                if (delete != null) {
-                    IconButton(onClick = delete) {
-                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete))
-                    }
+        // Node info
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = node.remark ?: node.address,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                modifier = Modifier.basicMarquee()
+            )
+            Spacer(Modifier.height(2.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = protocolPrefixMap[node.protocolPrefix]?.protocolType
+                        ?: stringResource(R.string.unknown),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                if (delayMs > 0 || delayMs == -2L) {
+                    Spacer(Modifier.width(8.dp))
+                    DelayChip(delayMs = delayMs)
                 }
             }
         }
+
+        // Actions
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (onFavorite != null) {
+                IconButton(
+                    onClick = onFavorite,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = if (favorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
+                        contentDescription = if (favorite)
+                            stringResource(R.string.remove_from_favorites)
+                        else stringResource(R.string.add_to_favorites),
+                        tint = if (favorite) MaterialTheme.colorScheme.tertiary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+            if (onTest != null) {
+                val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+                val scale by infiniteTransition.animateFloat(
+                    initialValue = 1f,
+                    targetValue = if (testing) 1.2f else 1f,
+                    animationSpec = infiniteRepeatable(
+                        animation = tween(800, easing = LinearEasing),
+                        repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
+                    ),
+                    label = "scale"
+                )
+                val alpha by infiniteTransition.animateFloat(
+                    initialValue = 1f,
+                    targetValue = if (testing) 0.4f else 1f,
+                    animationSpec = infiniteRepeatable(
+                        animation = tween(800, easing = LinearEasing),
+                        repeatMode = androidx.compose.animation.core.RepeatMode.Reverse
+                    ),
+                    label = "alpha"
+                )
+                IconButton(
+                    onClick = onTest,
+                    enabled = enableTest,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Speed,
+                        contentDescription = stringResource(R.string.test_url),
+                        modifier = Modifier
+                            .size(20.dp)
+                            .scale(scale),
+                        tint = if (enableTest)
+                            MaterialTheme.colorScheme.primary.copy(alpha = alpha)
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                    )
+                }
+            }
+            if (onShare != null) {
+                IconButton(
+                    onClick = onShare,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Share,
+                        contentDescription = stringResource(R.string.clipboard_export),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+            if (onEdit != null) {
+                IconButton(
+                    onClick = onEdit,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = stringResource(R.string.edit),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+            if (delete != null) {
+                IconButton(
+                    onClick = delete,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = stringResource(R.string.delete),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DelayChip(delayMs: Long) {
+    // Delay semantic colors: keep universal green/orange/red semantics, but tone down to Material-friendly saturation
+    val delayColor = when {
+        delayMs == -2L -> MaterialTheme.colorScheme.error
+        delayMs < 300 -> Color(0xFF2E7D32) // green 800
+        delayMs < 900 -> Color(0xFFE65100) // orange 900
+        else -> MaterialTheme.colorScheme.error
+    }
+    val displayText = if (delayMs == -2L)
+        stringResource(R.string.timeout)
+    else "${delayMs}ms"
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(delayColor.copy(alpha = 0.12f))
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = displayText,
+            style = MaterialTheme.typography.labelSmall,
+            color = delayColor,
+            fontWeight = FontWeight.SemiBold
+        )
     }
 }
 


### PR DESCRIPTION
Drop the random ColorMap avatar tint and hardcoded colors in favor of colorScheme tokens. Split into list mode (flat row, leading 3dp primary bar as the sole selection signal) and card mode (ElevatedCard for HomeScreen). Unify icons to outlined family, tighten typography and spacing, and use a softer inset divider.