### PR TITLE
feat: add HTTP and SOCKS proxy outbound support

### DIFF
--- a/app/src/main/java/com/android/xrayfa/dto/ProtocolConfigs.kt
+++ b/app/src/main/java/com/android/xrayfa/dto/ProtocolConfigs.kt
@@ -48,3 +48,21 @@ data class Hysteria2Config(
     val auth: String,
     val param: Map<String, String>
 )
+
+data class SocksConfig(
+    val protocol: Protocol = Protocol.SOCKS,
+    val remark: String? = null,
+    val server: String,
+    val port: Int,
+    val username: String? = null,
+    val password: String? = null
+)
+
+data class HttpConfig(
+    val protocol: Protocol = Protocol.HTTP,
+    val remark: String? = null,
+    val server: String,
+    val port: Int,
+    val username: String? = null,
+    val password: String? = null
+)

--- a/app/src/main/java/com/android/xrayfa/model/OutboundObject.kt
+++ b/app/src/main/java/com/android/xrayfa/model/OutboundObject.kt
@@ -55,6 +55,14 @@ data class Hysteria2OutboundConfigurationObject(
     val port: Int
 ): AbsOutboundConfigurationObject()
 
+data class SocksOutboundConfigurationObject(
+    val servers: List<HttpSocksServerObject>
+): AbsOutboundConfigurationObject()
+
+data class HttpOutboundConfigurationObject(
+    val servers: List<HttpSocksServerObject>
+): AbsOutboundConfigurationObject()
+
 data class ServerObject(
     val address: String,
     val port: Int,
@@ -79,6 +87,18 @@ data class ShadowSocksServerObject(
     val UotVersion:Int? = null,
     val level: Int? = null,
     val ivCheck: Boolean? = null // 新增: 兼容性字段
+)
+
+data class HttpSocksServerObject(
+    val address: String,
+    val port: Int,
+    val users: List<HttpSocksUserObject>? = null
+)
+
+data class HttpSocksUserObject(
+    val user: String,
+    val pass: String,
+    val level: Int? = null
 )
 
 data class UserObject(

--- a/app/src/main/java/com/android/xrayfa/model/protocol/Protocol.kt
+++ b/app/src/main/java/com/android/xrayfa/model/protocol/Protocol.kt
@@ -5,6 +5,8 @@ import com.android.xrayfa.model.protocol.Protocol.TROJAN
 import com.android.xrayfa.model.protocol.Protocol.VLESS
 import com.android.xrayfa.model.protocol.Protocol.VMESS
 import com.android.xrayfa.model.protocol.Protocol.HYSTERIA2
+import com.android.xrayfa.model.protocol.Protocol.HTTP
+import com.android.xrayfa.model.protocol.Protocol.SOCKS
 
 /**
  * @param protocolType protocol type == protocolPrefix
@@ -20,7 +22,11 @@ enum class Protocol(
 
     TROJAN("trojan"),
 
-    HYSTERIA2("hysteria2");
+    HYSTERIA2("hysteria2"),
+
+    SOCKS("socks"),
+
+    HTTP("http");
 
 
 }
@@ -29,12 +35,18 @@ val protocolsPrefix = listOf(
     VMESS.protocolType,
     SHADOWSOCKS.protocolType,
     TROJAN.protocolType,
-    HYSTERIA2.protocolType
+    HYSTERIA2.protocolType,
+    SOCKS.protocolType,
+    "socks5",
+    HTTP.protocolType
 )
 val protocolPrefixMap = mapOf(
     SHADOWSOCKS.protocolType to SHADOWSOCKS,
     VLESS.protocolType to VLESS,
     VMESS.protocolType to VMESS,
     TROJAN.protocolType to TROJAN,
-    HYSTERIA2.protocolType to HYSTERIA2
+    HYSTERIA2.protocolType to HYSTERIA2,
+    SOCKS.protocolType to SOCKS,
+    "socks5" to SOCKS,
+    HTTP.protocolType to HTTP
 )

--- a/app/src/main/java/com/android/xrayfa/parser/AbstractConfigParser.kt
+++ b/app/src/main/java/com/android/xrayfa/parser/AbstractConfigParser.kt
@@ -175,7 +175,7 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject,P>(
     }
 
 
-    fun getBaseRoutingObject(settingsState: SettingsState): RoutingObject {
+    fun getBaseRoutingObject(settingsState: SettingsState, tcpOnlyProxy: Boolean = false): RoutingObject {
         val targetType = object : TypeToken<List<RuleObject>?>() {}.type
         var rules: List<RuleObject>? = if (settingsState.routingMode == RoutingMode.GLOBAL) {
             getGlobalRules()
@@ -188,6 +188,14 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject,P>(
             rules = gson.fromJson<List<RuleObject>>(defaultRoutes, targetType)?.filterNotNull()
         }
 
+        // HTTP outbounds are TCP-only and cannot relay UDP. Without special handling, DNS queries and
+        // other UDP traffic would be routed to the proxy and silently fail, causing intermittent
+        // connectivity loss. Keep DNS/UDP off the proxy so name resolution keeps working.
+        // (SOCKS5 supports UDP, so it is not treated as TCP-only.)
+        if (tcpOnlyProxy) {
+            rules = getTcpOnlyProxyRules() + (rules ?: emptyList())
+        }
+
         return RoutingObject(
             domainStrategy = when(settingsState.domainStrategy) {
                 DomainStrategy.ASIS -> "AsIs"
@@ -196,6 +204,37 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject,P>(
                 else -> throw IllegalArgumentException("wrong domain strategy")
             },
             rules = rules
+        )
+    }
+
+    /**
+     * Extra routing rules used when the active proxy is a TCP-only protocol (http).
+     * HTTP proxies cannot forward UDP, so we must keep DNS and UDP traffic away from the proxy:
+     *  - all DNS (port 53) is resolved via direct connection (real network) so lookups never hang;
+     *  - QUIC (UDP/443) is blocked, forcing apps to fall back to TCP (also nicer for packet capture);
+     *  - any remaining UDP goes direct instead of into the dead-end proxy.
+     */
+    fun getTcpOnlyProxyRules(): List<RuleObject> {
+        return listOf(
+            RuleObject(
+                type = "field",
+                port = "53",
+                outboundTag = "direct",
+                ruleTag = "DNS Direct (TCP-only proxy)"
+            ),
+            RuleObject(
+                type = "field",
+                network = "udp",
+                port = "443",
+                outboundTag = "block",
+                ruleTag = "Block QUIC (TCP-only proxy)"
+            ),
+            RuleObject(
+                type = "field",
+                network = "udp",
+                outboundTag = "direct",
+                ruleTag = "UDP Direct (TCP-only proxy)"
+            )
         )
     }
 
@@ -290,6 +329,9 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject,P>(
                 settings = NoneOutboundConfigurationObject()
             )
         )
+        // Only HTTP proxies are truly TCP-only. SOCKS5 supports UDP (UDP ASSOCIATE) and Xray can relay
+        // it, so SOCKS is treated like any other UDP-capable proxy.
+        val tcpOnlyProxy = outbound.protocol == "http"
         val xrayConfig = XrayConfiguration(
             stats = emptyMap(), // enable
             api = getBaseAPIObject(),
@@ -298,7 +340,7 @@ abstract class AbstractConfigParser<T: AbsOutboundConfigurationObject,P>(
             policy = getBasePolicyObject(),
             inbounds = getInboundConfigs(settingsState),
             outbounds = outbounds,
-            routing = getBaseRoutingObject(settingsState),
+            routing = getBaseRoutingObject(settingsState, tcpOnlyProxy),
         )
         val config = Gson().toJson(xrayConfig)
         println(config)

--- a/app/src/main/java/com/android/xrayfa/parser/HttpConfigParser.kt
+++ b/app/src/main/java/com/android/xrayfa/parser/HttpConfigParser.kt
@@ -1,0 +1,102 @@
+package com.android.xrayfa.parser
+
+import com.android.xrayfa.XrayAppCompatFactory
+import com.android.xrayfa.common.GEO_LITE
+import com.android.xrayfa.common.repository.SettingsRepository
+import com.android.xrayfa.dto.HttpConfig
+import com.android.xrayfa.dto.Link
+import com.android.xrayfa.dto.Node
+import com.android.xrayfa.model.HttpOutboundConfigurationObject
+import com.android.xrayfa.model.HttpSocksServerObject
+import com.android.xrayfa.model.HttpSocksUserObject
+import com.android.xrayfa.model.OutboundObject
+import com.android.xrayfa.model.stream.StreamSettingsObject
+import com.android.xrayfa.utils.Device
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Parser for HTTP proxy outbounds.
+ *
+ * Supported share link formats:
+ *  - http://host:port#remark                (no authentication)
+ *  - http://user:pass@host:port#remark      (plain, percent-encoded credentials)
+ *
+ * See https://xtls.github.io/config/outbounds/http.html
+ */
+@Singleton
+class HttpConfigParser
+@Inject constructor(
+    override val settingsRepo: SettingsRepository,
+    override val gson: Gson
+) : AbstractConfigParser<HttpOutboundConfigurationObject, HttpConfig>() {
+
+    override fun decodeProtocol(url: String): HttpConfig {
+        require(url.startsWith("http://")) { "Not a valid HTTP proxy URL" }
+        return ProxyLinkUtils.decode(url) { remark, server, port, user, pass ->
+            HttpConfig(
+                remark = remark,
+                server = server,
+                port = if (port == -1) 8080 else port,
+                username = user,
+                password = pass
+            )
+        }
+    }
+
+    override fun encodeProtocol(protocol: HttpConfig): String {
+        return ProxyLinkUtils.encode(
+            scheme = "http",
+            server = protocol.server,
+            port = protocol.port,
+            username = protocol.username,
+            password = protocol.password,
+            remark = protocol.remark
+        )
+    }
+
+    override fun parseOutbound(url: String): OutboundObject<HttpOutboundConfigurationObject> {
+        val config = decodeProtocol(url)
+        val users = if (!config.username.isNullOrEmpty()) {
+            listOf(HttpSocksUserObject(user = config.username, pass = config.password ?: ""))
+        } else null
+        return OutboundObject(
+            tag = "proxy",
+            protocol = "http",
+            settings = HttpOutboundConfigurationObject(
+                servers = listOf(
+                    HttpSocksServerObject(
+                        address = config.server,
+                        port = config.port,
+                        users = users
+                    )
+                )
+            ),
+            streamSettings = StreamSettingsObject(
+                network = "tcp"
+            )
+        )
+    }
+
+    override suspend fun preParse(link: Link): Node {
+        val config = decodeProtocol(link.content)
+        return Node(
+            id = link.id,
+            url = link.content,
+            protocolPrefix = "http",
+            subscriptionId = link.subscriptionId,
+            port = config.port,
+            address = config.server,
+            selected = link.selected,
+            remark = config.remark,
+            countryISO = if (settingsRepo.settingsFlow.first().geoLiteInstall) {
+                Device.getCountryISOFromIp(
+                    geoPath = "${XrayAppCompatFactory.xrayPATH}/$GEO_LITE",
+                    ip = config.server
+                )
+            } else ""
+        )
+    }
+}

--- a/app/src/main/java/com/android/xrayfa/parser/ParserFactory.kt
+++ b/app/src/main/java/com/android/xrayfa/parser/ParserFactory.kt
@@ -16,7 +16,9 @@ class ParserFactory @Inject constructor(
     val vmessConfigParser: VMESSConfigParser,
     val trojanConfigParser: TrojanConfigParser,
     val shadowSocksConfigParser: ShadowSocksConfigParser,
-    val hysteria2ConfigParser: Hysteria2ConfigParser
+    val hysteria2ConfigParser: Hysteria2ConfigParser,
+    val socksConfigParser: SocksConfigParser,
+    val httpConfigParser: HttpConfigParser
 ) {
 
     fun getParser(url: String): AbstractConfigParser<*,*> {
@@ -26,6 +28,9 @@ class ParserFactory @Inject constructor(
             Protocol.TROJAN.protocolType -> trojanConfigParser
             Protocol.SHADOWSOCKS.protocolType -> shadowSocksConfigParser
             Protocol.HYSTERIA2.protocolType -> hysteria2ConfigParser
+            Protocol.SOCKS.protocolType -> socksConfigParser
+            "socks5" -> socksConfigParser
+            Protocol.HTTP.protocolType -> httpConfigParser
             else -> {
                 throw IllegalArgumentException("Unsupported protocol: $protocol")
             }

--- a/app/src/main/java/com/android/xrayfa/parser/SocksConfigParser.kt
+++ b/app/src/main/java/com/android/xrayfa/parser/SocksConfigParser.kt
@@ -1,0 +1,191 @@
+package com.android.xrayfa.parser
+
+import com.android.xrayfa.XrayAppCompatFactory
+import com.android.xrayfa.common.GEO_LITE
+import com.android.xrayfa.common.repository.SettingsRepository
+import com.android.xrayfa.dto.Link
+import com.android.xrayfa.dto.Node
+import com.android.xrayfa.dto.SocksConfig
+import com.android.xrayfa.model.HttpSocksServerObject
+import com.android.xrayfa.model.HttpSocksUserObject
+import com.android.xrayfa.model.OutboundObject
+import com.android.xrayfa.model.SocksOutboundConfigurationObject
+import com.android.xrayfa.model.stream.StreamSettingsObject
+import com.android.xrayfa.utils.Device
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.first
+import java.net.URI
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Parser for SOCKS proxy outbounds.
+ *
+ * Supported share link formats (aligned with the common v2rayN convention):
+ *  - socks://host:port#remark                        (no authentication)
+ *  - socks://user:pass@host:port#remark              (plain, percent-encoded credentials)
+ *  - socks://base64(user:pass)@host:port#remark      (base64 encoded credentials)
+ *
+ * See https://xtls.github.io/config/outbounds/socks.html
+ */
+@Singleton
+class SocksConfigParser
+@Inject constructor(
+    override val settingsRepo: SettingsRepository,
+    override val gson: Gson
+) : AbstractConfigParser<SocksOutboundConfigurationObject, SocksConfig>() {
+
+    override fun decodeProtocol(url: String): SocksConfig {
+        require(url.startsWith("socks://") || url.startsWith("socks5://")) { "Not a valid SOCKS URL" }
+        return ProxyLinkUtils.decode(url) { remark, server, port, user, pass ->
+            SocksConfig(
+                remark = remark,
+                server = server,
+                port = if (port == -1) 1080 else port,
+                username = user,
+                password = pass
+            )
+        }
+    }
+
+    override fun encodeProtocol(protocol: SocksConfig): String {
+        return ProxyLinkUtils.encode(
+            scheme = "socks",
+            server = protocol.server,
+            port = protocol.port,
+            username = protocol.username,
+            password = protocol.password,
+            remark = protocol.remark
+        )
+    }
+
+    override fun parseOutbound(url: String): OutboundObject<SocksOutboundConfigurationObject> {
+        val config = decodeProtocol(url)
+        val users = if (!config.username.isNullOrEmpty()) {
+            listOf(HttpSocksUserObject(user = config.username, pass = config.password ?: ""))
+        } else null
+        return OutboundObject(
+            tag = "proxy",
+            protocol = "socks",
+            settings = SocksOutboundConfigurationObject(
+                servers = listOf(
+                    HttpSocksServerObject(
+                        address = config.server,
+                        port = config.port,
+                        users = users
+                    )
+                )
+            ),
+            streamSettings = StreamSettingsObject(
+                network = "tcp"
+            )
+        )
+    }
+
+    override suspend fun preParse(link: Link): Node {
+        val config = decodeProtocol(link.content)
+        return Node(
+            id = link.id,
+            url = link.content,
+            protocolPrefix = "socks",
+            subscriptionId = link.subscriptionId,
+            port = config.port,
+            address = config.server,
+            selected = link.selected,
+            remark = config.remark,
+            countryISO = if (settingsRepo.settingsFlow.first().geoLiteInstall) {
+                Device.getCountryISOFromIp(
+                    geoPath = "${XrayAppCompatFactory.xrayPATH}/$GEO_LITE",
+                    ip = config.server
+                )
+            } else ""
+        )
+    }
+}
+
+/**
+ * Shared decode/encode helpers for the SOCKS and HTTP proxy share links, which use an
+ * identical `scheme://[credentials@]host:port#remark` structure.
+ */
+internal object ProxyLinkUtils {
+
+    fun <T> decode(
+        url: String,
+        factory: (remark: String?, server: String, port: Int, user: String?, pass: String?) -> T
+    ): T {
+        val uri = URI(url)
+        val host = uri.host ?: throw IllegalArgumentException("Invalid proxy URL: missing host")
+        val port = uri.port
+        val remark = if (uri.fragment.isNullOrEmpty()) null else percentDecode(uri.fragment)
+
+        var username: String? = null
+        var password: String? = null
+        val rawUserInfo = uri.userInfo
+        if (!rawUserInfo.isNullOrEmpty()) {
+            // Plain "user:pass" is used as-is. Otherwise try base64 (v2rayN style), but only accept
+            // the decoded value when it actually looks like "user:pass"; this avoids garbling a plain
+            // username that has no password (e.g. socks://user@host) which is also valid base64.
+            val userInfo = if (rawUserInfo.contains(":")) {
+                rawUserInfo
+            } else {
+                val decoded = tryBase64Decode(rawUserInfo)
+                if (decoded.contains(":")) decoded else rawUserInfo
+            }
+            val idx = userInfo.indexOf(":")
+            if (idx >= 0) {
+                username = percentDecode(userInfo.substring(0, idx))
+                password = percentDecode(userInfo.substring(idx + 1))
+            } else {
+                username = percentDecode(userInfo)
+            }
+        }
+        return factory(remark, host, port, username, password)
+    }
+
+    fun encode(
+        scheme: String,
+        server: String,
+        port: Int,
+        username: String?,
+        password: String?,
+        remark: String?
+    ): String = buildString {
+        append(scheme).append("://")
+        if (!username.isNullOrEmpty()) {
+            append(urlEncode(username))
+            if (!password.isNullOrEmpty()) {
+                append(":").append(urlEncode(password))
+            }
+            append("@")
+        }
+        append(server).append(":").append(port)
+        if (!remark.isNullOrEmpty()) {
+            append("#").append(urlEncode(remark))
+        }
+    }
+
+    private fun tryBase64Decode(value: String): String {
+        return try {
+            String(Base64.getDecoder().decode(value))
+        } catch (e: Exception) {
+            value
+        }
+    }
+
+    private fun percentDecode(s: String?): String {
+        if (s == null) return ""
+        return try {
+            URLDecoder.decode(s, StandardCharsets.UTF_8.name())
+        } catch (e: Exception) {
+            s
+        }
+    }
+
+    private fun urlEncode(s: String): String {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8.name())
+    }
+}

--- a/app/src/main/java/com/android/xrayfa/ui/component/EditScreen.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/EditScreen.kt
@@ -98,6 +98,7 @@ fun EditScreen(
     
     // Protocol Specific
     var id by remember { mutableStateOf("") } // UUID or Password
+    var username by remember { mutableStateOf("") } // HTTP / SOCKS username
     var flow by remember { mutableStateOf("") } 
     var vlessEncryption by remember { mutableStateOf("none") }
     var ssMethod by remember { mutableStateOf("aes-256-gcm") } 
@@ -200,6 +201,22 @@ fun EditScreen(
                         hysteria2ObfsPassword = config.param["obfs-password"] ?: ""
                         allowInsecure = config.param["allowInsecure"] == "1"
                     }
+                    Protocol.SOCKS.protocolType -> {
+                        selectedProtocol = Protocol.SOCKS
+                        val config = detailViewmodel.parseSocksProtocol(initialContent)
+                        address = config.server
+                        port = config.port.toString()
+                        username = config.username ?: ""
+                        id = config.password ?: ""
+                    }
+                    Protocol.HTTP.protocolType -> {
+                        selectedProtocol = Protocol.HTTP
+                        val config = detailViewmodel.parseHttpProtocol(initialContent)
+                        address = config.server
+                        port = config.port.toString()
+                        username = config.username ?: ""
+                        id = config.password ?: ""
+                    }
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -274,7 +291,8 @@ fun EditScreen(
                                     hysteria2Obfs = hysteria2Obfs,
                                     hysteria2ObfsPassword = hysteria2ObfsPassword,
                                     hysteria2Alpn = hysteria2Alpn,
-                                    allowInsecure = allowInsecure
+                                    allowInsecure = allowInsecure,
+                                    username = username
                                 )
                                 onBack()
                             },
@@ -307,7 +325,17 @@ fun EditScreen(
                 Text("Basic Settings", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
                 EditTextField(remarks, { remarks = it }, "Remarks")
                 EditTextField(address, { address = it }, "Address")
-                EditTextField(port, { if (it.all { c -> c.isDigit() }) port = it }, "Port")
+                EditTextField(
+                    port,
+                    { input ->
+                        if (input.all { c -> c.isDigit() } &&
+                            (input.isEmpty() || (input.toIntOrNull()?.let { it in 0..65535 } == true))
+                        ) {
+                            port = input
+                        }
+                    },
+                    "Port (0-65535)"
+                )
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
@@ -329,6 +357,14 @@ fun EditScreen(
                     }
                     Protocol.TROJAN -> {
                         EditTextField(id, { id = it }, "Password")
+                    }
+                    Protocol.SOCKS -> {
+                        EditTextField(username, { username = it }, "Username (optional)")
+                        EditTextField(id, { id = it }, "Password (optional)")
+                    }
+                    Protocol.HTTP -> {
+                        EditTextField(username, { username = it }, "Username (optional)")
+                        EditTextField(id, { id = it }, "Password (optional)")
                     }
                     Protocol.HYSTERIA2 -> {
                         EditTextField(id, { id = it }, "Auth")
@@ -356,7 +392,10 @@ fun EditScreen(
                     }
                 }
 
-                if (selectedProtocol != Protocol.HYSTERIA2) {
+                val hasTransportSettings = selectedProtocol != Protocol.HYSTERIA2 &&
+                        selectedProtocol != Protocol.SOCKS &&
+                        selectedProtocol != Protocol.HTTP
+                if (hasTransportSettings) {
                     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
                     // 3. Transport Settings

--- a/app/src/main/java/com/android/xrayfa/viewmodel/DetailViewmodel.kt
+++ b/app/src/main/java/com/android/xrayfa/viewmodel/DetailViewmodel.kt
@@ -9,6 +9,8 @@ import com.android.xrayfa.dto.VMESSConfig
 import com.android.xrayfa.dto.ShadowSocksConfig
 import com.android.xrayfa.dto.TrojanConfig
 import com.android.xrayfa.dto.Hysteria2Config
+import com.android.xrayfa.dto.SocksConfig
+import com.android.xrayfa.dto.HttpConfig
 import com.android.xrayfa.model.protocol.Protocol
 import com.android.xrayfa.parser.ParserFactory
 import com.android.xrayfa.repository.NodeRepository
@@ -39,6 +41,12 @@ class DetailViewmodel(
     fun parseHysteria2Protocol(content:String): Hysteria2Config {
         return parserFactory.hysteria2ConfigParser.decodeProtocol(content)
     }
+    fun parseSocksProtocol(content:String): SocksConfig {
+        return parserFactory.socksConfigParser.decodeProtocol(content)
+    }
+    fun parseHttpProtocol(content:String): HttpConfig {
+        return parserFactory.httpConfigParser.decodeProtocol(content)
+    }
 
     fun saveNode(
         nodeId: Int = -1,
@@ -63,7 +71,8 @@ class DetailViewmodel(
         hysteria2Obfs: String = "",
         hysteria2ObfsPassword: String = "",
         hysteria2Alpn: String = "",
-        allowInsecure: Boolean = false
+        allowInsecure: Boolean = false,
+        username: String = ""
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             val url = when (protocol) {
@@ -190,6 +199,30 @@ class DetailViewmodel(
                             port = port,
                             auth = uuidOrPassword,
                             param = params
+                        )
+                    )
+                }
+
+                Protocol.SOCKS -> {
+                    parserFactory.socksConfigParser.encodeProtocol(
+                        SocksConfig(
+                            remark = remarks,
+                            server = address,
+                            port = port,
+                            username = username.ifBlank { null },
+                            password = uuidOrPassword.ifBlank { null }
+                        )
+                    )
+                }
+
+                Protocol.HTTP -> {
+                    parserFactory.httpConfigParser.encodeProtocol(
+                        HttpConfig(
+                            remark = remarks,
+                            server = address,
+                            port = port,
+                            username = username.ifBlank { null },
+                            password = uuidOrPassword.ifBlank { null }
                         )
                     )
                 }


### PR DESCRIPTION
Add http/socks outbound parsers, DTOs and models following the existing protocol pattern, wired into ParserFactory, DetailViewmodel and the EditScreen form (with username/password fields and 0-65535 port validation). For the TCP-only HTTP proxy, route DNS/UDP directly and block QUIC so name resolution stays reliable; SOCKS5 keeps UDP over the proxy. Fix base64 userinfo decoding corrupting a password-less username, and accept the socks5:// scheme alias.