### PR TITLE
fix(subscription): correct node linking and alias rules

### DIFF
--- a/app/src/main/java/com/android/xrayfa/dao/SubscriptionDao.kt
+++ b/app/src/main/java/com/android/xrayfa/dao/SubscriptionDao.kt
@@ -17,7 +17,7 @@ interface SubscriptionDao {
 
 
     @Insert
-    suspend fun addSubscription(vararg subscription: Subscription)
+    suspend fun addSubscription(subscription: Subscription): Long
 
 
     @Delete

--- a/app/src/main/java/com/android/xrayfa/repository/SubscriptionRepository.kt
+++ b/app/src/main/java/com/android/xrayfa/repository/SubscriptionRepository.kt
@@ -35,11 +35,12 @@ class SubscriptionRepository
 
     val allSubscriptions = subscriptionDao.getALLSubscriptions()
 
-    suspend fun addSubscription(subscription: Subscription) {
-        subscriptionDao.addSubscription(subscription)
+    suspend fun addSubscription(subscription: Subscription): Long {
+        return subscriptionDao.addSubscription(subscription)
     }
 
     suspend fun deleteSubscription(subscription: Subscription) {
+        nodeRepository.deleteLinkBySubscriptionId(subscription.id)
         subscriptionDao.deleteSubscription(subscription)
     }
 
@@ -56,6 +57,10 @@ class SubscriptionRepository
         subscriptionId: Int,
         extraHeaders: Map<String, String> = emptyMap()
     ): SubscriptionMeta {
+        if (subscriptionId > 0) {
+            nodeRepository.deleteLinkBySubscriptionId(0)
+        }
+
         val currentSettings = settingsRepository.settingsFlow.first()
 
         val requestBuilder = Request.Builder()

--- a/app/src/main/java/com/android/xrayfa/ui/component/SubscriptionScreen.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/SubscriptionScreen.kt
@@ -78,6 +78,7 @@ import com.android.xrayfa.ui.navigation.Config
 import com.android.xrayfa.ui.navigation.NavigateDestination
 import com.android.xrayfa.ui.navigation.ScanQR
 import com.android.xrayfa.viewmodel.SubscriptionViewmodel
+import com.android.xrayfa.viewmodel.XrayViewmodel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -89,6 +90,7 @@ import java.net.URL
 @Composable
 fun SubscriptionScreen(
     viewmodel: SubscriptionViewmodel,
+    xrayViewmodel: XrayViewmodel,
     onNavigate: (NavigateDestination) -> Unit
 ) {
     val context = LocalContext.current
@@ -102,7 +104,16 @@ fun SubscriptionScreen(
     var preNodeId by remember(subscription) { mutableStateOf(subscription.preNodeId) }
     var nextNodeId by remember(subscription) { mutableStateOf(subscription.nextNodeId) }
     var nickNameIsNull by remember { mutableStateOf(false) }
+    var nickNameIsDuplicate by remember { mutableStateOf(false) }
     var urlIsNullOrInvalid by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isBottomSheetShow, subscription.id, nickName) {
+        if (isBottomSheetShow) {
+            val resolved = nickName.trim()
+            nickNameIsNull = resolved.isBlank()
+            nickNameIsDuplicate = viewmodel.isMarkDuplicate(resolved, subscription.id)
+        }
+    }
 
     val deleteDialog by viewmodel.deleteDialog.collectAsState()
     val requesting by viewmodel.requesting.collectAsState()
@@ -236,12 +247,16 @@ fun SubscriptionScreen(
                                         if (result.isEmpty()) {
                                             Toast.makeText(context, R.string.cancel, Toast.LENGTH_SHORT).show()
                                         } else {
-                                            viewmodel.addSubscription(
+                                            viewmodel.addOrUpdateSubscription(
                                                 subscription = Subscription(
                                                     id = 0,
                                                     url = result,
-                                                    mark = context.getString(R.string.import_manually)
-                                                )
+                                                    mark = viewmodel.generateQrSubscriptionMark()
+                                                ),
+                                                onSuccess = { id ->
+                                                    xrayViewmodel.selectSubscription(id)
+                                                    onNavigate(Config)
+                                                }
                                             )
                                         }
                                     })
@@ -296,6 +311,7 @@ fun SubscriptionScreen(
                             OutlinedCard(
                                 onClick = {
                                     viewmodel.refreshSubscription(item.url, item.id) {
+                                        xrayViewmodel.selectSubscription(item.id)
                                         onNavigate(Config)
                                     }
                                 },
@@ -412,15 +428,22 @@ fun SubscriptionScreen(
                         )
 
                         OutlinedTextField(
-                            value = nickName?: subscriptionMeta?.profileTitle.orEmpty(),
+                            value = nickName,
                             onValueChange = {
                                 nickName = it
-                                nickNameIsNull = nickName?.isBlank()?: subscriptionMeta?.profileTitle.orEmpty().isBlank()
+                                val resolved = it.trim()
+                                nickNameIsNull = resolved.isBlank()
+                                nickNameIsDuplicate = viewmodel.isMarkDuplicate(resolved, subscription.id)
                             },
                             label = { Text(stringResource(R.string.nick_name)) },
                             singleLine = true,
                             modifier = Modifier.fillMaxWidth(),
-                            isError = nickNameIsNull,
+                            isError = nickNameIsNull || nickNameIsDuplicate,
+                            supportingText = if (nickNameIsDuplicate) {
+                                { Text(stringResource(R.string.err_subscription_mark_duplicate)) }
+                            } else {
+                                null
+                            },
                             shape = RoundedCornerShape(12.dp)
                         )
 
@@ -462,17 +485,23 @@ fun SubscriptionScreen(
                             Spacer(Modifier.width(8.dp))
                             Button(
                                 onClick = {
+                                    val resolvedMark = nickName.trim()
+                                    nickNameIsNull = resolvedMark.isBlank()
+                                    nickNameIsDuplicate = viewmodel.isMarkDuplicate(resolvedMark, subscription.id)
+                                    if (nickNameIsNull || nickNameIsDuplicate) return@Button
+
                                     validateThenConfirm(url) {
                                         viewmodel.addOrUpdateSubscription(
                                             subscription = Subscription(
                                                 id = subscription.id,
-                                                mark = nickName,
+                                                mark = resolvedMark,
                                                 url = url,
                                                 preNodeId = preNodeId,
                                                 nextNodeId = nextNodeId,
                                                 isAutoUpdate = subscription.isAutoUpdate,
                                             ),
-                                            onSuccess = {
+                                            onSuccess = { id ->
+                                                xrayViewmodel.selectSubscription(id)
                                                 onNavigate(Config)
                                             }
                                         )
@@ -481,7 +510,7 @@ fun SubscriptionScreen(
                                         urlIsNullOrInvalid = it
                                     }
                                 },
-                                enabled = !urlIsNullOrInvalid,
+                                enabled = !urlIsNullOrInvalid && !nickNameIsNull && !nickNameIsDuplicate,
                                 shape = RoundedCornerShape(12.dp)
                             ) {
                                 Text(stringResource(R.string.confirm))

--- a/app/src/main/java/com/android/xrayfa/ui/component/XrayFAContainer.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/XrayFAContainer.kt
@@ -215,7 +215,7 @@ fun XrayFAContainer(
                             key = key,
                             metadata = XrayFASceneStrategy.subscription()
                         ) {
-                            SubscriptionScreen(subscriptViewmodel) {
+                            SubscriptionScreen(subscriptViewmodel, xrayViewmodel) {
                                 if (it is Config) navBackStack.routeBack() else navBackStack.routeTo(it)
                             }
                         }

--- a/app/src/main/java/com/android/xrayfa/viewmodel/SubscriptionViewmodel.kt
+++ b/app/src/main/java/com/android/xrayfa/viewmodel/SubscriptionViewmodel.kt
@@ -72,6 +72,23 @@ class SubscriptionViewmodel(
         }
     }
 
+    fun isMarkDuplicate(mark: String, excludeSubscriptionId: Int = 0): Boolean {
+        val trimmed = mark.trim()
+        if (trimmed.isEmpty()) return false
+        return _subscriptions.value.any { subscription ->
+            subscription.id != excludeSubscriptionId && subscription.mark.trim() == trimmed
+        }
+    }
+
+    fun generateQrSubscriptionMark(): String {
+        val existingMarks = _subscriptions.value.map { it.mark.trim() }.toSet()
+        for (i in 1..1000) {
+            val candidate = "QR_$i"
+            if (candidate !in existingMarks) return candidate
+        }
+        return "QR_1000"
+    }
+
     fun addSubscription(subscription: Subscription) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.addSubscription(subscription)
@@ -90,35 +107,77 @@ class SubscriptionViewmodel(
 
     fun addOrUpdateSubscription(
         subscription: Subscription,
-        onSuccess: () -> Unit = {}
+        onSuccess: (Int) -> Unit = {}
     ) {
         if (subscription.id == 0) {
-            refreshSubscription(
-                url = subscription.url,
-                subscriptionId = 0
-            ) {
-                val mark = subscription.mark.ifEmpty {
-                    it.profileTitle.orEmpty()
-                }
-
-                _subscriptionMeta.value = _subscriptionMeta.value?.copy(profileTitle = mark)
-
+            viewModelScope.launch(Dispatchers.IO) {
+                _requestingSubscription.value = true
                 val sub = Subscription(
-                    id = subscription.id,
+                    id = 0,
                     url = subscription.url,
-                    mark = mark,
+                    mark = subscription.mark,
                     preNodeId = subscription.preNodeId,
                     nextNodeId = subscription.nextNodeId,
                     isAutoUpdate = subscription.isAutoUpdate
                 )
-                viewModelScope.launch(Dispatchers.IO) {
-                    repository.addSubscription(sub)
+                var newId = 0
+                try {
+                    newId = repository.addSubscription(sub).toInt()
+                    val meta = repository.fetchAndSaveNodes(subscription.url, newId)
+                    val mark = subscription.mark.ifEmpty { meta.profileTitle.orEmpty() }
+                    if (mark.isNotEmpty() && isMarkDuplicate(mark, newId)) {
+                        throw IllegalStateException("Duplicate subscription mark: $mark")
+                    }
+                    if (mark.isNotEmpty() && mark != sub.mark) {
+                        repository.updateSubscription(
+                            Subscription(
+                                id = newId,
+                                url = sub.url,
+                                mark = mark,
+                                preNodeId = sub.preNodeId,
+                                nextNodeId = sub.nextNodeId,
+                                isAutoUpdate = sub.isAutoUpdate
+                            )
+                        )
+                    }
+                    _subscriptionMeta.value = meta.copy(
+                        profileTitle = mark.ifEmpty { meta.profileTitle }
+                    )
+                    withContext(Dispatchers.Main) { onSuccess(newId) }
+                } catch (e: Exception) {
+                    if (newId > 0) {
+                        repository.deleteSubscription(
+                            Subscription(
+                                id = newId,
+                                url = sub.url,
+                                mark = sub.mark,
+                                preNodeId = sub.preNodeId,
+                                nextNodeId = sub.nextNodeId,
+                                isAutoUpdate = sub.isAutoUpdate
+                            )
+                        )
+                    }
+                    launch {
+                        _subscribeError.value = true
+                        delay(2000L)
+                        _subscribeError.value = false
+                    }
+                } finally {
+                    _requestingSubscription.value = false
                 }
-                onSuccess()
             }
         } else {
             viewModelScope.launch(Dispatchers.IO) {
+                if (isMarkDuplicate(subscription.mark, subscription.id)) {
+                    launch {
+                        _subscribeError.value = true
+                        delay(2000L)
+                        _subscribeError.value = false
+                    }
+                    return@launch
+                }
                 repository.updateSubscription(subscription)
+                withContext(Dispatchers.Main) { onSuccess(subscription.id) }
             }
         }
     }

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -159,6 +159,7 @@
     <string name="next_node">다음</string>
     <string name="none">없음</string>
     <string name="share_subscription">구독 공유</string>
+    <string name="err_subscription_mark_duplicate">이미 사용 중인 닉네임입니다</string>
 
     <string name="apps_permission_required_title">권한 필요</string>
     <string name="apps_permission_required_desc">개별 앱 프록시를 위해 설치된 앱 목록을 표시하려면, 시스템 설정에서 %1$s에 대해 "모든 앱" / "모든 패키지 요청" 권한을 허용하십시오.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -158,6 +158,7 @@
     <string name="next_node">Пост-узел</string>
     <string name="none">Нет</string>
     <string name="share_subscription">Поделиться подпиской</string>
+    <string name="err_subscription_mark_duplicate">Такое имя уже существует</string>
 
     <string name="apps_permission_required_title">Требуется разрешение</string>
     <string name="apps_permission_required_desc">Чтобы отобразить список установленных приложений для прокси отдельных приложений, предоставьте разрешение «Все приложения» / «Запрос всех пакетов» для %1$s в настройках системы.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -142,6 +142,7 @@
     <string name="next_node">后置节点</string>
     <string name="none">无</string>
     <string name="share_subscription">分享订阅</string>
+    <string name="err_subscription_mark_duplicate">别名已存在，不能重复</string>
 
     <string name="apps_permission_required_title">需要查询应用权限</string>
     <string name="apps_permission_required_desc">为了显示已安装的应用列表以便选择代理对象，请在系统设置中为 %1$s 授予"读取应用列表"权限。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="next_node">Next Node</string>
     <string name="none">None</string>
     <string name="share_subscription">Share Subscription</string>
+    <string name="err_subscription_mark_duplicate">This nickname already exists</string>
 
     <string name="apps_permission_required_title">Permission required</string>
     <string name="apps_permission_required_desc">To list installed apps for per-app proxy, please grant the "All apps" / "Query all packages" permission to %1$s in system settings.</string>


### PR DESCRIPTION
Insert subscriptions before fetching nodes using the Room-generated id, cascade-delete nodes on subscription removal, and auto-select the active subscription after import. Enforce unique subscription nicknames in the UI and assign QR imports names like QR_1..QR_1000.

Fixes #464