### PR TITLE
feat(home): redesign home screen for a more polished, professional lo…

### DIFF
--- a/app/src/main/java/com/android/xrayfa/ui/component/HomeScreen.kt
+++ b/app/src/main/java/com/android/xrayfa/ui/component/HomeScreen.kt
@@ -5,14 +5,20 @@ import android.net.VpnService
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -32,6 +38,8 @@ import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Dns
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -56,6 +64,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
@@ -156,13 +165,11 @@ fun CompactHomeContent(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp),
+            .padding(horizontal = 20.dp, vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(24.dp)
+        verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        StatusCard(isRunning, upSpeed, downSpeed)
-
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         V2rayStarterLarge(xrayViewmodel) {
             if (selectedNode == null) {
@@ -175,19 +182,14 @@ fun CompactHomeContent(
             } else true
         }
 
-        Text(
-            text = stringResource(if (isRunning) R.string.connected else R.string.disconnect),
-            style = MaterialTheme.typography.titleMedium,
-            color = if (isRunning) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-        )
+        ConnectionStatusLabel(isRunning = isRunning)
 
-        Spacer(modifier = Modifier.height(16.dp))
+        StatusCard(isRunning, upSpeed, downSpeed)
 
         selectedNode?.let { node ->
-            Text(
+            SectionHeader(
                 text = stringResource(R.string.connection_detail),
-                style = MaterialTheme.typography.labelLarge,
-                modifier = Modifier.align(Alignment.Start)
+                modifier = Modifier.fillMaxWidth()
             )
             NodeCard(
                 node = node,
@@ -196,16 +198,12 @@ fun CompactHomeContent(
                 testing = testing,
                 roundCorner = true,
                 enableTest = isRunning,
-//                backgroundColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
             )
-        } ?: ElevatedCard(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(24.dp)
-        ) {
-            Box(Modifier.padding(24.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                Text(stringResource(R.string.select_configuration_notify), style = MaterialTheme.typography.bodyLarge)
-            }
-        }
+        } ?: EmptyNodeCard(
+            text = stringResource(R.string.select_configuration_notify)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 
@@ -222,28 +220,40 @@ fun ExpandedHomeContent(
     val context = LocalContext.current
 
     Row(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
-        horizontalArrangement = Arrangement.spacedBy(24.dp)
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalArrangement = Arrangement.spacedBy(32.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Column(
-            modifier = Modifier.weight(1f).fillMaxHeight(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            V2rayStarterLarge(xrayViewmodel) { selectedNode != null }
-            Spacer(modifier = Modifier.height(24.dp))
-            Text(
-                text = stringResource(if (isRunning) R.string.connected else R.string.disconnect),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                color = if (isRunning) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+        ElevatedCard(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
             )
-            Spacer(modifier = Modifier.height(32.dp))
-            StatusCard(isRunning, upSpeed, downSpeed)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                V2rayStarterLarge(xrayViewmodel) { selectedNode != null }
+                Spacer(modifier = Modifier.height(28.dp))
+                ConnectionStatusLabel(isRunning = isRunning, large = true)
+                Spacer(modifier = Modifier.height(36.dp))
+                StatusCard(isRunning, upSpeed, downSpeed)
+            }
         }
 
         Column(
-            modifier = Modifier.weight(1.2f).fillMaxHeight(),
+            modifier = Modifier
+                .weight(1.1f)
+                .fillMaxHeight(),
             verticalArrangement = Arrangement.Center
         ) {
             Text(
@@ -260,16 +270,92 @@ fun ExpandedHomeContent(
                     testing = testing,
                     roundCorner = true,
                     enableTest = isRunning,
-//                    backgroundColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                 )
-            } ?: ElevatedCard(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(24.dp)
+            } ?: EmptyNodeCard(
+                text = stringResource(R.string.no_configuration),
+                contentPadding = 40.dp
+            )
+        }
+    }
+}
+
+@Composable
+fun SectionHeader(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun ConnectionStatusLabel(isRunning: Boolean, large: Boolean = false) {
+    val statusColor = if (isRunning) MaterialTheme.colorScheme.primary
+    else MaterialTheme.colorScheme.outline
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(if (large) 12.dp else 10.dp)
+                    .clip(CircleShape)
+                    .background(statusColor)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = stringResource(if (isRunning) R.string.connected else R.string.not_connected),
+                style = if (large) MaterialTheme.typography.headlineSmall
+                else MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = statusColor
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = stringResource(if (isRunning) R.string.tap_to_disconnect else R.string.tap_to_connect),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun EmptyNodeCard(text: String, contentPadding: Dp = 28.dp) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(contentPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer),
+                contentAlignment = Alignment.Center
             ) {
-                Box(Modifier.padding(48.dp).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                    Text(stringResource(R.string.no_configuration), style = MaterialTheme.typography.bodyLarge)
-                }
+                Icon(
+                    imageVector = Icons.Outlined.Dns,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(24.dp)
+                )
             }
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }
@@ -279,23 +365,32 @@ fun StatusCard(isRunning: Boolean, upSpeed: Double, downSpeed: Double) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
     ) {
         Row(
-            modifier = Modifier.padding(20.dp).fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier
+                .padding(horizontal = 20.dp, vertical = 18.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             SpeedItem(
+                modifier = Modifier.weight(1f),
                 label = stringResource(R.string.upload_data),
                 speed = upSpeed,
                 icon = Icons.Default.KeyboardArrowUp,
+                active = isRunning,
                 color = MaterialTheme.colorScheme.primary
             )
-            VerticalDivider(modifier = Modifier.height(40.dp).width(1.dp))
+            VerticalDivider(modifier = Modifier.height(36.dp).width(1.dp))
             SpeedItem(
+                modifier = Modifier.weight(1f),
                 label = stringResource(R.string.download_data),
                 speed = downSpeed,
                 icon = Icons.Default.KeyboardArrowDown,
+                active = isRunning,
                 color = MaterialTheme.colorScheme.secondary
             )
         }
@@ -303,18 +398,42 @@ fun StatusCard(isRunning: Boolean, upSpeed: Double, downSpeed: Double) {
 }
 
 @Composable
-fun SpeedItem(label: String, speed: Double, icon: ImageVector, color: Color) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+fun SpeedItem(
+    label: String,
+    speed: Double,
+    icon: ImageVector,
+    color: Color,
+    active: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(color.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center
+        ) {
             Icon(icon, contentDescription = null, tint = color, modifier = Modifier.size(20.dp))
-            Spacer(Modifier.width(4.dp))
-            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
-        Text(
-            text = "${String.format("%.1f", speed)} KB/s",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold
-        )
+        Spacer(Modifier.width(10.dp))
+        Column {
+            Text(
+                text = label.replaceFirstChar { it.uppercase() },
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "${String.format("%.1f", if (active) speed else 0.0)} KB/s",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
     }
 }
 
@@ -326,13 +445,22 @@ fun V2rayStarterLarge(
     val isRunning by xrayViewmodel.isServiceRunning.collectAsState()
     val context = LocalContext.current
 
-    val color by animateColorAsState(
-        targetValue = if (isRunning) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-        animationSpec = tween(durationMillis = 500),
-        label = "color"
-    )
+    val primary = MaterialTheme.colorScheme.primary
+    val tertiary = MaterialTheme.colorScheme.tertiary
+    val surfaceVariant = MaterialTheme.colorScheme.surfaceVariant
 
-    val shadowColor = if (isRunning) MaterialTheme.colorScheme.primary.copy(alpha = 0.3f) else Color.Transparent
+    val buttonBrush = if (isRunning) {
+        Brush.linearGradient(colors = listOf(primary, tertiary))
+    } else {
+        Brush.linearGradient(
+            colors = listOf(
+                surfaceVariant,
+                surfaceVariant.copy(alpha = 0.65f)
+            )
+        )
+    }
+
+    val shadowColor = if (isRunning) primary.copy(alpha = 0.45f) else Color.Transparent
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -360,39 +488,77 @@ fun V2rayStarterLarge(
             )
         )
     }
+
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .size(160.dp)
-            .shadow(
-                elevation = if (isRunning) 20.dp else 0.dp,
-                shape = CircleShape,
-                spotColor = shadowColor,
-                ambientColor = shadowColor
-            )
-            .clip(CircleShape)
-            .background(color)
+        modifier = Modifier.size(200.dp)
     ) {
-        IconButton(
-            onClick = {
-                if (!onCheck()) return@IconButton
-                if (!isRunning) {
-                    val prepare = VpnService.prepare(context)
-                    if (prepare != null) launcher.launch(prepare)
-                    else xrayViewmodel.startXrayService(context)
-                } else {
-                    xrayViewmodel.stopXrayService(context)
-                }
-            },
-            modifier = Modifier.fillMaxSize()
-                .scale(scale.value)
-        ) {
-            Icon(
-                imageVector = if (isRunning) Icons.Default.Done else ImageVector.vectorResource(R.drawable.ic_power),
-                contentDescription = "Toggle Service",
-                tint = if (isRunning) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(64.dp)
-            )
+        // Expanding pulse rings while connected
+        if (isRunning) {
+            PulseRings(color = primary)
         }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(148.dp)
+                .scale(scale.value)
+                .shadow(
+                    elevation = if (isRunning) 24.dp else 4.dp,
+                    shape = CircleShape,
+                    spotColor = shadowColor,
+                    ambientColor = shadowColor
+                )
+                .clip(CircleShape)
+                .background(buttonBrush)
+        ) {
+            IconButton(
+                onClick = {
+                    if (!onCheck()) return@IconButton
+                    if (!isRunning) {
+                        val prepare = VpnService.prepare(context)
+                        if (prepare != null) launcher.launch(prepare)
+                        else xrayViewmodel.startXrayService(context)
+                    } else {
+                        xrayViewmodel.stopXrayService(context)
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Icon(
+                    imageVector = if (isRunning) Icons.Default.Done else ImageVector.vectorResource(R.drawable.ic_power),
+                    contentDescription = "Toggle Service",
+                    tint = if (isRunning) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(60.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.PulseRings(color: Color) {
+    val transition = rememberInfiniteTransition(label = "pulse")
+    repeat(2) { index ->
+        val progress by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 2400, easing = LinearEasing),
+                initialStartOffset = StartOffset(index * 1200)
+            ),
+            label = "ring$index"
+        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .scale(0.74f + progress * 0.26f)
+                .clip(CircleShape)
+                .border(
+                    width = 2.dp,
+                    color = color.copy(alpha = (1f - progress) * 0.5f),
+                    shape = CircleShape
+                )
+        )
     }
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,6 +3,9 @@
     <string name="stop">停止</string>
     <string name="disconnect">已断开</string>
     <string name="connected">已连接</string>
+    <string name="not_connected">未连接</string>
+    <string name="tap_to_connect">点击按钮以连接</string>
+    <string name="tap_to_disconnect">点击按钮以断开</string>
     <string name="home">主页</string>
     <string name="config">配置</string>
     <string name="logcat">日志</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
     <string name="stop">stop</string>
     <string name="disconnect">Disconnect</string>
     <string name="connected">Connected</string>
+    <string name="not_connected">Not connected</string>
+    <string name="tap_to_connect">Tap the button to connect</string>
+    <string name="tap_to_disconnect">Tap the button to disconnect</string>
     <string name="home">Home</string>
     <string name="config">Config</string>
     <string name="logcat">Logcat</string>


### PR DESCRIPTION
…ok (#468)

Rework the connect button into a gradient hero with animated pulse rings when connected, add a clearer status label with helper subtitle, refine the speed stats card and empty/node states, and tighten spacing so node details fit without scrolling on smaller screens. Keep the expanded tablet layout balanced as a two-pane dashboard.