### PR TITLE
feat(ui): pin Config/Home nav and dock a detached search control

### DIFF
--- a/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/RootContent.kt
+++ b/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/RootContent.kt
@@ -9,16 +9,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -27,6 +23,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.DeleteForever
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Speed
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.AlertDialog
@@ -65,11 +62,11 @@ import com.android.xrayfa.shared.ui.config.shouldCommitOverlayScroll
 import com.android.xrayfa.shared.ui.config.SharedConfigSection
 import com.android.xrayfa.shared.ui.config.SharedEditScreen
 import com.android.xrayfa.shared.ui.home.HomeTopBar
-import com.android.xrayfa.shared.ui.nav.FloatingNavBarHeight
+import com.android.xrayfa.shared.ui.nav.FloatingNavBottomFade
 import com.android.xrayfa.shared.ui.nav.FloatingNavBottomMargin
-import com.android.xrayfa.shared.ui.nav.FloatingNavContentClearance
 import com.android.xrayfa.shared.ui.nav.FloatingNavItem
 import com.android.xrayfa.shared.ui.nav.XrayFloatingNav
+import com.android.xrayfa.shared.ui.nav.rememberFloatingNavClearance
 import com.android.xrayfa.shared.ui.nav.toFloatingNavItem
 import com.android.xrayfa.shared.ui.platform.LocalPlatformRootHooks
 import com.android.xrayfa.shared.ui.settings.SharedRouteSettingsScreen
@@ -101,28 +98,11 @@ fun RootContent(
     val stackIdle = stack.active.configuration is RootStackConfig.Idle
     val selectedTab = pages.items.getOrNull(pages.selectedIndex)?.configuration ?: RootTab.Home
     var searchExpandedCoversNav by remember { mutableStateOf(false) }
-    val floatingNavVisible = remember { mutableStateOf(true) }
-    val hideNavOnScroll =
-        remember {
-            object : NestedScrollConnection {
-                override fun onPreScroll(
-                    available: Offset,
-                    source: NestedScrollSource,
-                ): Offset {
-                    when {
-                        available.y < -8f -> floatingNavVisible.value = false
-                        available.y > 8f -> floatingNavVisible.value = true
-                    }
-                    return Offset.Zero
-                }
-            }
-        }
-    val showBottomNav = stackIdle && !searchExpandedCoversNav && floatingNavVisible.value
+    var requestOpenSearch by remember { mutableStateOf(false) }
+    val showBottomNav = stackIdle && !searchExpandedCoversNav
+    val configLabels = rememberConfigUiLabels()
 
-    LaunchedEffect(selectedTab, stackIdle) {
-        if (stackIdle) {
-            floatingNavVisible.value = true
-        }
+    LaunchedEffect(selectedTab) {
         if (selectedTab != RootTab.Config) {
             searchExpandedCoversNav = false
         }
@@ -158,7 +138,6 @@ fun RootContent(
                     HomeTabScreen(
                         component = child.component,
                         onSettingsClick = component::openSettings,
-                        hideNavOnScroll = hideNavOnScroll,
                     )
                 is RootComponent.Child.Config ->
                     ConfigTabScreen(
@@ -167,9 +146,10 @@ fun RootContent(
                         onOpenNodeEdit = component::openNodeEdit,
                         onOpenSubscriptions = component::openSubscriptions,
                         onOpenQrScanner = component::openQrScanner,
-                        hideNavOnScroll = hideNavOnScroll,
                         onSearchExpanded = { searchExpandedCoversNav = it },
                         forceCollapseSearch = selectedTab != RootTab.Config,
+                        openSearch = requestOpenSearch,
+                        onOpenSearchConsumed = { requestOpenSearch = false },
                     )
             }
         }
@@ -264,10 +244,7 @@ fun RootContent(
             visible = showBottomNav,
             enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
             exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
-            modifier =
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .windowInsetsPadding(WindowInsets.navigationBars),
+            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
         ) {
             val navItems =
                 listOf(
@@ -282,16 +259,35 @@ fun RootContent(
                         label = stringResource(Res.string.home),
                     ),
                 )
-            XrayFloatingNav(
-                items = navItems,
-                selectedId = selectedTab.name,
-                onItemSelected = { item ->
-                    component.selectTab(
-                        if (item.id == RootTab.Config.name) RootTab.Config else RootTab.Home,
-                    )
-                },
-                modifier = Modifier.padding(bottom = FloatingNavBottomMargin, start = 16.dp, end = 16.dp),
-            )
+            Box(modifier = Modifier.fillMaxWidth()) {
+                FloatingNavBottomFade(modifier = Modifier.align(Alignment.BottomCenter))
+                XrayFloatingNav(
+                    items = navItems,
+                    selectedId = selectedTab.name,
+                    onItemSelected = { item ->
+                        component.selectTab(
+                            if (item.id == RootTab.Config.name) RootTab.Config else RootTab.Home,
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            imageVector = Icons.Outlined.Search,
+                            contentDescription = configLabels.searchLabel,
+                            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            modifier = Modifier.size(26.dp),
+                        )
+                    },
+                    onTrailingClick = {
+                        requestOpenSearch = true
+                        component.selectTab(RootTab.Config)
+                    },
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                            .padding(bottom = FloatingNavBottomMargin, start = 16.dp, end = 16.dp),
+                )
+            }
         }
     }
 }
@@ -303,14 +299,16 @@ private fun ConfigTabScreen(
     onOpenNodeEdit: (Int) -> Unit,
     onOpenSubscriptions: () -> Unit,
     onOpenQrScanner: () -> Unit,
-    hideNavOnScroll: NestedScrollConnection,
     onSearchExpanded: (Boolean) -> Unit,
     forceCollapseSearch: Boolean,
+    openSearch: Boolean,
+    onOpenSearchConsumed: () -> Unit,
 ) {
     val platformHooks = LocalPlatformRootHooks.current
     val configLabels = rememberConfigUiLabels()
     val settingsLabels = rememberSettingsUiLabels()
     val configState by component.state.subscribeAsState()
+    val configBottomClearance = rememberFloatingNavClearance()
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var pendingOverlayScroll by remember { mutableStateOf<OverlayScrollPending?>(null) }
@@ -331,6 +329,7 @@ private fun ConfigTabScreen(
 
     SharedListScaffold(
         title = stringResource(Res.string.config),
+        largeTitle = false,
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         actions = {
             IconButton(onClick = { onOpenNodeEdit(0) }) {
@@ -398,8 +397,7 @@ private fun ConfigTabScreen(
                 modifier = Modifier.fillMaxSize(),
                 labels = configLabels,
                 listState = listState,
-                listContentPadding = PaddingValues(bottom = FloatingNavContentClearance),
-                nestedScrollConnection = hideNavOnScroll,
+                listContentPadding = PaddingValues(bottom = configBottomClearance),
                 nodeDelayMap = configState.nodeDelayMap,
                 onNodeSelected = { node ->
                     component.onSelectNode(node.id)
@@ -441,10 +439,9 @@ private fun ConfigTabScreen(
                         )
                 },
                 forceCollapsed = forceCollapseSearch,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(end = 20.dp, bottom = FloatingNavContentClearance),
+                showCollapsedTrigger = false,
+                openSearch = openSearch,
+                onOpenSearchConsumed = onOpenSearchConsumed,
             )
         }
     }
@@ -495,14 +492,10 @@ private fun ConfigTabScreen(
 private fun HomeTabScreen(
     component: HomeComponent,
     onSettingsClick: () -> Unit,
-    hideNavOnScroll: NestedScrollConnection,
 ) {
     val homeLabels = rememberHomeUiLabels()
     val platformHooks = LocalPlatformRootHooks.current
-    val homeNavClearance =
-        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() +
-            FloatingNavBarHeight +
-            FloatingNavBottomMargin
+    val homeNavClearance = rememberFloatingNavClearance(extraAboveBar = 8.dp)
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
@@ -520,8 +513,7 @@ private fun HomeTabScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(bottom = homeNavClearance)
-                    .nestedScroll(hideNavOnScroll),
+                    .padding(bottom = homeNavClearance),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/chrome/SharedListScaffold.kt
+++ b/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/chrome/SharedListScaffold.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.material3.Text
 fun SharedListScaffold(
     title: String,
     modifier: Modifier = Modifier,
+    largeTitle: Boolean = true,
     navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
     footerUnderBar: @Composable () -> Unit = {},
@@ -30,24 +32,47 @@ fun SharedListScaffold(
     floatingActionButton: @Composable () -> Unit = {},
     content: @Composable (innerBottomPadding: androidx.compose.foundation.layout.PaddingValues) -> Unit,
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+    val scrollBehavior =
+        if (largeTitle) {
+            TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+        } else {
+            null
+        }
     Scaffold(
-        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier =
+            if (scrollBehavior != null) {
+                modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+            } else {
+                modifier
+            },
         contentWindowInsets = contentWindowInsets,
         floatingActionButton = floatingActionButton,
         topBar = {
             Column {
-                LargeTopAppBar(
-                    title = { Text(title, fontWeight = FontWeight.Bold) },
-                    navigationIcon = navigationIcon,
-                    actions = actions,
-                    scrollBehavior = scrollBehavior,
-                    colors =
-                        TopAppBarDefaults.largeTopAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.background,
-                            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-                        ),
-                )
+                if (largeTitle) {
+                    LargeTopAppBar(
+                        title = { Text(title, fontWeight = FontWeight.Bold) },
+                        navigationIcon = navigationIcon,
+                        actions = actions,
+                        scrollBehavior = scrollBehavior,
+                        colors =
+                            TopAppBarDefaults.largeTopAppBarColors(
+                                containerColor = MaterialTheme.colorScheme.background,
+                                scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                            ),
+                    )
+                } else {
+                    TopAppBar(
+                        title = { Text(title, fontWeight = FontWeight.Bold) },
+                        navigationIcon = navigationIcon,
+                        actions = actions,
+                        colors =
+                            TopAppBarDefaults.topAppBarColors(
+                                containerColor = MaterialTheme.colorScheme.background,
+                                scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                            ),
+                    )
+                }
                 footerUnderBar()
             }
         },

--- a/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/chrome/SharedSearchChrome.kt
+++ b/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/chrome/SharedSearchChrome.kt
@@ -57,6 +57,7 @@ internal fun SharedSearchChrome(
     searchLabel: String,
     onImeSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
+    showCollapsedTrigger: Boolean = true,
     results: @Composable ColumnScope.() -> Unit,
 ) {
     val clearLabel = stringResource(Res.string.search_clear)
@@ -115,7 +116,7 @@ internal fun SharedSearchChrome(
                 }
             }
         }
-    } else {
+    } else if (showCollapsedTrigger) {
         Surface(
             modifier =
                 modifier

--- a/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/config/ActualConfigSearchFab.kt
+++ b/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/config/ActualConfigSearchFab.kt
@@ -38,6 +38,9 @@ fun ActualConfigSearchFab(
     onResultChosen: (nodeId: Int) -> Unit,
     modifier: Modifier = Modifier,
     forceCollapsed: Boolean = false,
+    showCollapsedTrigger: Boolean = true,
+    openSearch: Boolean = false,
+    onOpenSearchConsumed: () -> Unit = {},
 ) {
     ConfigSearchBarImpl(
         searchQuery = searchQuery,
@@ -49,6 +52,9 @@ fun ActualConfigSearchFab(
         onResultChosen = onResultChosen,
         modifier = modifier,
         forceCollapsed = forceCollapsed,
+        showCollapsedTrigger = showCollapsedTrigger,
+        openSearch = openSearch,
+        onOpenSearchConsumed = onOpenSearchConsumed,
     )
 }
 
@@ -64,6 +70,9 @@ internal fun ConfigSearchBarImpl(
     onResultChosen: (nodeId: Int) -> Unit,
     modifier: Modifier = Modifier,
     forceCollapsed: Boolean = false,
+    showCollapsedTrigger: Boolean = true,
+    openSearch: Boolean = false,
+    onOpenSearchConsumed: () -> Unit = {},
 ) {
     var query by remember { mutableStateOf(searchQuery) }
     var active by remember { mutableStateOf(false) }
@@ -88,8 +97,11 @@ internal fun ConfigSearchBarImpl(
         }
     }
 
-    LaunchedEffect(forceCollapsed) {
-        if (forceCollapsed) {
+    LaunchedEffect(openSearch, forceCollapsed) {
+        if (openSearch && !forceCollapsed) {
+            active = true
+            onOpenSearchConsumed()
+        } else if (forceCollapsed && !openSearch) {
             active = false
         }
     }
@@ -111,6 +123,7 @@ internal fun ConfigSearchBarImpl(
         searchLabel = searchLabel,
         onImeSearch = onImeSearch,
         modifier = modifier,
+        showCollapsedTrigger = showCollapsedTrigger,
         results = {
             ConfigSearchOverlayResults(
                 searchQuery = searchQuery,

--- a/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/nav/XrayFloatingNav.kt
+++ b/shared/src/commonMain/kotlin/com/android/xrayfa/shared/ui/nav/XrayFloatingNav.kt
@@ -14,14 +14,18 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Language
@@ -38,11 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,12 +57,38 @@ import kotlin.math.floor
 
 val FloatingNavBarHeight = 64.dp
 val FloatingNavBottomMargin = 8.dp
+/** Extra space so the last Config row can rest above the pill. */
+val FloatingNavExtraContentPadding = 24.dp
 private val BarCorner = 32.dp
 private val IndicatorInset = 6.dp
 private val IndicatorCorner = 28.dp
+private val BottomFadeExtra = 36.dp
 
-/** Config list content padding so the last row can scroll above the pill. */
-val FloatingNavContentClearance = FloatingNavBarHeight + FloatingNavBottomMargin + 16.dp
+@Composable
+fun rememberFloatingNavClearance(extraAboveBar: Dp = FloatingNavExtraContentPadding): Dp {
+    val systemBottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    return systemBottom + FloatingNavBarHeight + FloatingNavBottomMargin + extraAboveBar
+}
+
+@Composable
+fun FloatingNavBottomFade(modifier: Modifier = Modifier) {
+    val fadeHeight = rememberFloatingNavClearance(extraAboveBar = BottomFadeExtra)
+    val background = MaterialTheme.colorScheme.background
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(fadeHeight)
+                .background(
+                    Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        0.4f to background.copy(alpha = 0.55f),
+                        0.72f to background.copy(alpha = 0.88f),
+                        1f to background,
+                    ),
+                ),
+    )
+}
 
 data class FloatingNavItem(
     val id: String,
@@ -79,6 +111,8 @@ fun XrayFloatingNav(
     modifier: Modifier = Modifier,
     selectedColor: Color = MaterialTheme.colorScheme.primary,
     unselectedColor: Color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+    trailingContent: @Composable (() -> Unit)? = null,
+    onTrailingClick: (() -> Unit)? = null,
 ) {
     val density = LocalDensity.current
     val itemCount = items.size.coerceAtLeast(1)
@@ -96,12 +130,14 @@ fun XrayFloatingNav(
             ) {
                 280.dp
             } else {
-                (maxWidth * 0.75f).coerceAtMost(320.dp)
+                (maxWidth * 0.62f).coerceAtMost(280.dp).coerceAtLeast(200.dp)
             }
+        val chromeColor = MaterialTheme.colorScheme.surfaceContainerHighest
 
-        Box(
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            contentAlignment = Alignment.Center,
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
                 modifier =
@@ -110,9 +146,9 @@ fun XrayFloatingNav(
                         .height(FloatingNavBarHeight)
                         .clip(RoundedCornerShape(BarCorner)),
                 shape = RoundedCornerShape(BarCorner),
-                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
-                shadowElevation = 6.dp,
-                tonalElevation = 2.dp,
+                color = chromeColor,
+                shadowElevation = 10.dp,
+                tonalElevation = 6.dp,
             ) {
                 BoxWithConstraints(
                     modifier =
@@ -120,93 +156,123 @@ fun XrayFloatingNav(
                             .fillMaxSize()
                             .clip(RoundedCornerShape(BarCorner)),
                 ) {
-                    val maxWidthPx = constraints.maxWidth.toFloat().coerceAtLeast(1f)
-                    val slotWidthPx = maxWidthPx / itemCount
-                    val slotStartPx = slotWidthPx * selectedIndex
-                    val maxOffsetPx = (maxWidthPx - slotWidthPx).coerceAtLeast(0f)
-                    val slotWidthDp = with(density) { floor(slotWidthPx.toDouble()).toFloat().toDp() }
+                        val maxWidthPx = constraints.maxWidth.toFloat().coerceAtLeast(1f)
+                        val slotWidthPx = maxWidthPx / itemCount
+                        val slotStartPx = slotWidthPx * selectedIndex
+                        val maxOffsetPx = (maxWidthPx - slotWidthPx).coerceAtLeast(0f)
+                        val slotWidthDp = with(density) { floor(slotWidthPx.toDouble()).toFloat().toDp() }
 
-                    LaunchedEffect(selectedIndex, slotWidthPx, maxWidthPx) {
-                        val target = slotStartPx.coerceIn(0f, maxOffsetPx)
-                        animOffsetX.snapTo(animOffsetX.value.coerceIn(0f, maxOffsetPx))
-                        animOffsetX.animateTo(
-                            targetValue = target,
-                            animationSpec =
-                                spring(
-                                    dampingRatio = Spring.DampingRatioNoBouncy,
-                                    stiffness = Spring.StiffnessMedium,
-                                ),
+                        LaunchedEffect(selectedIndex, slotWidthPx, maxWidthPx) {
+                            val target = slotStartPx.coerceIn(0f, maxOffsetPx)
+                            animOffsetX.snapTo(animOffsetX.value.coerceIn(0f, maxOffsetPx))
+                            animOffsetX.animateTo(
+                                targetValue = target,
+                                animationSpec =
+                                    spring(
+                                        dampingRatio = Spring.DampingRatioNoBouncy,
+                                        stiffness = Spring.StiffnessMedium,
+                                    ),
+                            )
+                        }
+
+                        Box(
+                            modifier =
+                                Modifier
+                                    .offset {
+                                        IntOffset(animOffsetX.value.coerceIn(0f, maxOffsetPx).toInt(), 0)
+                                    }
+                                    .width(slotWidthDp)
+                                    .fillMaxHeight()
+                                    .padding(IndicatorInset)
+                                    .clip(RoundedCornerShape(IndicatorCorner))
+                                    .background(selectedColor.copy(alpha = 0.12f)),
                         )
-                    }
 
-                    // Sliding capsule inset 6dp from the outer pill (matches Android).
-                    Box(
-                        modifier =
-                            Modifier
-                                .offset {
-                                    IntOffset(animOffsetX.value.coerceIn(0f, maxOffsetPx).toInt(), 0)
-                                }
-                                .width(slotWidthDp)
-                                .fillMaxHeight()
-                                .padding(IndicatorInset)
-                                .clip(RoundedCornerShape(IndicatorCorner))
-                                .background(selectedColor.copy(alpha = 0.12f)),
-                    )
-
-                    Row(modifier = Modifier.fillMaxSize()) {
-                        items.forEachIndexed { index, item ->
-                            val selected = index == selectedIndex
-                            val iconScale by
-                                animateFloatAsState(
-                                    targetValue = if (selected) 1.15f else 1f,
-                                    animationSpec = tween(300),
-                                )
-                            val contentColor by
-                                animateColorAsState(
-                                    targetValue = if (selected) selectedColor else unselectedColor,
-                                    animationSpec = tween(300),
-                                )
-
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .weight(1f)
-                                        .fillMaxHeight()
-                                        .clickable(
-                                            indication = null,
-                                            interactionSource = remember { MutableInteractionSource() },
-                                        ) { onItemSelected(item) },
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center,
-                                    modifier = Modifier.padding(horizontal = 4.dp),
-                                ) {
-                                    Icon(
-                                        imageVector = item.icon,
-                                        contentDescription = item.label,
-                                        tint = contentColor,
-                                        modifier =
-                                            Modifier
-                                                .size(26.dp)
-                                                .scale(iconScale),
+                        Row(modifier = Modifier.fillMaxSize()) {
+                            items.forEachIndexed { index, item ->
+                                val selected = index == selectedIndex
+                                val iconScale by
+                                    animateFloatAsState(
+                                        targetValue = if (selected) 1.15f else 1f,
+                                        animationSpec = tween(300),
                                     )
-                                    if (selected) {
-                                        Text(
-                                            text = item.label,
-                                            color = contentColor,
-                                            fontSize = 11.sp,
-                                            lineHeight = 12.sp,
-                                            fontWeight = FontWeight.Bold,
-                                            textAlign = TextAlign.Center,
-                                            maxLines = 1,
-                                            modifier = Modifier.padding(top = 2.dp),
+                                val contentColor by
+                                    animateColorAsState(
+                                        targetValue = if (selected) selectedColor else unselectedColor,
+                                        animationSpec = tween(300),
+                                    )
+
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .weight(1f)
+                                            .fillMaxHeight()
+                                            .clickable(
+                                                indication = null,
+                                                interactionSource = remember { MutableInteractionSource() },
+                                            ) { onItemSelected(item) },
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center,
+                                        modifier = Modifier.padding(horizontal = 4.dp),
+                                    ) {
+                                        Icon(
+                                            imageVector = item.icon,
+                                            contentDescription = item.label,
+                                            tint = contentColor,
+                                            modifier =
+                                                Modifier
+                                                    .size(26.dp)
+                                                    .scale(iconScale),
                                         )
+                                        if (selected) {
+                                            Text(
+                                                text = item.label,
+                                                color = contentColor,
+                                                fontSize = 11.sp,
+                                                lineHeight = 12.sp,
+                                                fontWeight = FontWeight.Bold,
+                                                textAlign = TextAlign.Center,
+                                                maxLines = 1,
+                                                modifier = Modifier.padding(top = 2.dp),
+                                            )
+                                        }
                                     }
                                 }
                             }
                         }
+                    }
+            }
+            if (trailingContent != null) {
+                Box(modifier = Modifier.width(12.dp).height(FloatingNavBarHeight))
+                Surface(
+                    modifier =
+                        Modifier
+                            .size(FloatingNavBarHeight)
+                            .clip(CircleShape)
+                            .then(
+                                if (onTrailingClick != null) {
+                                    Modifier.clickable(
+                                        indication = null,
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        onClick = onTrailingClick,
+                                    )
+                                } else {
+                                    Modifier
+                                },
+                            ),
+                    shape = CircleShape,
+                    color = chromeColor,
+                    shadowElevation = 10.dp,
+                    tonalElevation = 6.dp,
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        trailingContent()
                     }
                 }
             }


### PR DESCRIPTION
Keep the bottom chrome always visible, use a compact Config title, and give the last list rows room above the bar. Search sits in a separate circle beside the pill so the dock reads as one control without a shared background.